### PR TITLE
Introduce tooltip component

### DIFF
--- a/examples/storybook/postcss.config.js
+++ b/examples/storybook/postcss.config.js
@@ -1,4 +1,6 @@
-export const plugins = {
-  tailwindcss: {},
-  autoprefixer: {},
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 };

--- a/examples/storybook/src/stories/Tooltip.stories.tsx
+++ b/examples/storybook/src/stories/Tooltip.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import * as React from "react";
+import { Tooltip, type TooltipProps } from "@synopsisapp/symbiosis-ui";
+
+const meta: Meta<typeof Tooltip.Root> = {
+  title: "Components/Tooltip",
+  component: Tooltip.Root,
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Tooltip.Root>;
+
+export const Uncontrolled: Story = {
+  decorators: [
+    (Story) => (
+      <div className="flex flex-col gap-4">
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args: TooltipProps["Root"]) => (
+    <Tooltip.Root {...args}>
+      <Tooltip.Trigger>
+        <span>Hover me</span>
+      </Tooltip.Trigger>
+      <Tooltip.Content label="Tooltip label" />
+    </Tooltip.Root>
+  ),
+  argTypes: {
+    defaultOpen: {
+      control: false,
+      table: {
+        defaultValue: { summary: "false" },
+        type: { summary: "boolean" },
+      },
+      description:
+        "The open state of the tooltip when it is initially rendered. Use when you do not need to control its open state.",
+      required: false,
+    },
+    open: {
+      control: {
+        type: "boolean",
+      },
+      table: {
+        defaultValue: { summary: "false" },
+      },
+      type: "boolean",
+      description:
+        "The controlled open state of the tooltip. Must be used in conjunction with onOpenChange.",
+      defaultValue: false,
+      required: false,
+    },
+    onOpenChange: {
+      table: {
+        type: { summary: "(open: boolean) => void" },
+      },
+      description:
+        "Event handler called when the open state of the tooltip changes.",
+      control: false,
+      required: false,
+    },
+  },
+};
+
+export const Controlled: Story = {
+  decorators: [
+    (Story) => (
+      <div className="flex flex-col gap-4">
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => {
+    const [open, setOpen] = React.useState(false);
+    return (
+      <div className="flex flex-col gap-4">
+        <Tooltip.Root {...args} open={open} onOpenChange={setOpen}>
+          <Tooltip.Trigger>
+            <span>Hover me</span>
+          </Tooltip.Trigger>
+          <Tooltip.Content label="Controlled Tooltip" />
+        </Tooltip.Root>
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+        const ControlledTooltip = () => {
+          const [open, setOpen] = React.useState(false);
+
+          return (
+              <Tooltip.Root  open={open} onOpenChange={setOpen}>
+                <Tooltip.Trigger>
+                  <span>Hover me</span>
+                </Tooltip.Trigger>
+                <Tooltip.Content label="Controlled Tooltip" />
+              </Tooltip.Root>
+          );
+        };
+        `,
+        language: "jsx",
+        type: "code",
+      },
+    },
+  },
+};

--- a/examples/storybook/src/stories/Tooltip.stories.tsx
+++ b/examples/storybook/src/stories/Tooltip.stories.tsx
@@ -15,7 +15,7 @@ type Story = StoryObj<typeof Tooltip.Root>;
 export const Uncontrolled: Story = {
   decorators: [
     (Story) => (
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4 items-start">
         <Story />
       </div>
     ),
@@ -67,7 +67,7 @@ export const Uncontrolled: Story = {
 export const Controlled: Story = {
   decorators: [
     (Story) => (
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4 items-start">
         <Story />
       </div>
     ),
@@ -75,14 +75,12 @@ export const Controlled: Story = {
   render: (args) => {
     const [open, setOpen] = React.useState(false);
     return (
-      <div className="flex flex-col gap-4">
-        <Tooltip.Root {...args} open={open} onOpenChange={setOpen}>
-          <Tooltip.Trigger>
-            <span>Hover me</span>
-          </Tooltip.Trigger>
-          <Tooltip.Content label="Controlled Tooltip" />
-        </Tooltip.Root>
-      </div>
+      <Tooltip.Root {...args} open={open} onOpenChange={setOpen}>
+        <Tooltip.Trigger>
+          <span>Hover me</span>
+        </Tooltip.Trigger>
+        <Tooltip.Content label="Controlled Tooltip" />
+      </Tooltip.Root>
     );
   },
   parameters: {
@@ -107,4 +105,24 @@ export const Controlled: Story = {
       },
     },
   },
+};
+
+export const CustomContent: Story = {
+  decorators: [
+    (Story) => (
+      <div className="flex flex-col gap-4 items-start">
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args: TooltipProps["Root"]) => (
+    <Tooltip.Root {...args}>
+      <Tooltip.Trigger>
+        <span>Hover me</span>
+      </Tooltip.Trigger>
+      <Tooltip.Content className="bg-mainColors-light-200 rounded-none">
+        <div>Popover content</div>
+      </Tooltip.Content>
+    </Tooltip.Root>
+  ),
 };

--- a/examples/storybook/src/stories/Tooltip.stories.tsx
+++ b/examples/storybook/src/stories/Tooltip.stories.tsx
@@ -6,13 +6,6 @@ const meta: Meta<typeof Tooltip.Root> = {
   title: "Components/Tooltip",
   component: Tooltip.Root,
   tags: ["autodocs"],
-};
-
-export default meta;
-
-type Story = StoryObj<typeof Tooltip.Root>;
-
-export const Uncontrolled: Story = {
   decorators: [
     (Story) => (
       <div className="flex flex-col gap-4 items-start">
@@ -20,6 +13,13 @@ export const Uncontrolled: Story = {
       </div>
     ),
   ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Tooltip.Root>;
+
+export const Uncontrolled: Story = {
   render: (args: TooltipProps["Root"]) => (
     <Tooltip.Root {...args}>
       <Tooltip.Trigger>
@@ -65,13 +65,6 @@ export const Uncontrolled: Story = {
 };
 
 export const Controlled: Story = {
-  decorators: [
-    (Story) => (
-      <div className="flex flex-col gap-4 items-start">
-        <Story />
-      </div>
-    ),
-  ],
   render: (args) => {
     const [open, setOpen] = React.useState(false);
     return (
@@ -87,18 +80,18 @@ export const Controlled: Story = {
     docs: {
       source: {
         code: `
-        const ControlledTooltip = () => {
-          const [open, setOpen] = React.useState(false);
+const ControlledTooltip = () => {
+  const [open, setOpen] = React.useState(false);
 
-          return (
-              <Tooltip.Root  open={open} onOpenChange={setOpen}>
-                <Tooltip.Trigger>
-                  <span>Hover me</span>
-                </Tooltip.Trigger>
-                <Tooltip.Content label="Controlled Tooltip" />
-              </Tooltip.Root>
-          );
-        };
+  return (
+      <Tooltip.Root  open={open} onOpenChange={setOpen}>
+        <Tooltip.Trigger>
+          <span>Hover me</span>
+        </Tooltip.Trigger>
+        <Tooltip.Content label="Controlled Tooltip" />
+      </Tooltip.Root>
+  );
+};
         `,
         language: "jsx",
         type: "code",
@@ -108,13 +101,6 @@ export const Controlled: Story = {
 };
 
 export const CustomContent: Story = {
-  decorators: [
-    (Story) => (
-      <div className="flex flex-col gap-4 items-start">
-        <Story />
-      </div>
-    ),
-  ],
   render: (args: TooltipProps["Root"]) => (
     <Tooltip.Root {...args}>
       <Tooltip.Trigger>

--- a/examples/storybook/src/stories/Tooltip.stories.tsx
+++ b/examples/storybook/src/stories/Tooltip.stories.tsx
@@ -47,8 +47,7 @@ export const Uncontrolled: Story = {
         defaultValue: { summary: "false" },
       },
       type: "boolean",
-      description:
-        "The controlled open state of the tooltip. Must be used in conjunction with onOpenChange.",
+      description: "The controlled open state of the tooltip. Must be used in conjunction with onOpenChange.",
       defaultValue: false,
       required: false,
     },
@@ -56,8 +55,7 @@ export const Uncontrolled: Story = {
       table: {
         type: { summary: "(open: boolean) => void" },
       },
-      description:
-        "Event handler called when the open state of the tooltip changes.",
+      description: "Event handler called when the open state of the tooltip changes.",
       control: false,
       required: false,
     },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,6 +45,7 @@
   "peerDependencies": {
     "@radix-ui/react-checkbox": "^1.1.1",
     "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-tooltip": "^1.1.2",
     "@tailwindcss/typography": "^0.5.13",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/packages/ui/src/components/Tooltip/index.tsx
+++ b/packages/ui/src/components/Tooltip/index.tsx
@@ -1,0 +1,80 @@
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { Text } from "../Text";
+import { cn } from "../../utils/cn";
+import type {
+  TooltipRootProps,
+  TooltipContentProps,
+  TooltipTriggerProps,
+} from "./types";
+
+export const TooltipRoot = ({
+  children,
+  defaultOpen,
+  open,
+  onOpenChange,
+}: TooltipRootProps) => {
+  return (
+    <TooltipPrimitive.Provider>
+      <TooltipPrimitive.Root
+        delayDuration={100}
+        open={open}
+        onOpenChange={onOpenChange}
+        defaultOpen={defaultOpen}
+      >
+        {children}
+      </TooltipPrimitive.Root>
+    </TooltipPrimitive.Provider>
+  );
+};
+
+TooltipRoot.displayName = "Tooltip.Root";
+
+const classnames = cn(
+  "py-2 px-3 rounded-md bg-gray-700 text-white max-w-[200px]",
+  "will-change-[transform,opacity]",
+  "data-[state=delayed-open]:data-[side=top]:animate-slide-up-and-fade",
+  "data-[state=delayed-open]:data-[side=right]:animate-slide-right-and-fade",
+  "data-[state=delayed-open]:data-[side=left]:animate-slide-left-and-fade",
+  "data-[state=delayed-open]:data-[side=bottom]:animate-slide-down-and-fade"
+);
+
+export const TooltipContent = ({ children, label }: TooltipContentProps) => {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        sideOffset={5}
+        asChild
+        forceMount
+        className={classnames}
+      >
+        <div>
+          {label ? (
+            <Text variant="body-small-200" noTranslations className="m-0 p-0">
+              {label}
+            </Text>
+          ) : (
+            children
+          )}
+        </div>
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+};
+
+TooltipContent.displayName = "Tooltip.Content";
+
+export const TooltipTrigger = ({ children }: TooltipTriggerProps) => {
+  return (
+    <TooltipPrimitive.Trigger asChild>
+      <div>{children}</div>
+    </TooltipPrimitive.Trigger>
+  );
+};
+
+TooltipTrigger.displayName = "Tooltip.Trigger";
+
+export const Tooltip = {
+  Root: TooltipRoot,
+  Content: TooltipContent,
+  Trigger: TooltipTrigger,
+};

--- a/packages/ui/src/components/Tooltip/index.tsx
+++ b/packages/ui/src/components/Tooltip/index.tsx
@@ -1,27 +1,13 @@
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { Text } from "../Text";
 import { cn } from "../../utils/cn";
-import type {
-  TooltipRootProps,
-  TooltipContentProps,
-  TooltipTriggerProps,
-} from "./types";
+import type { TooltipRootProps, TooltipContentProps, TooltipTriggerProps } from "./types";
 import { sharedTooltipStyles } from "./styles";
 
-export const TooltipRoot = ({
-  children,
-  defaultOpen,
-  open,
-  onOpenChange,
-}: TooltipRootProps) => {
+export const TooltipRoot = ({ children, defaultOpen, open, onOpenChange }: TooltipRootProps) => {
   return (
     <TooltipPrimitive.Provider>
-      <TooltipPrimitive.Root
-        delayDuration={100}
-        open={open}
-        onOpenChange={onOpenChange}
-        defaultOpen={defaultOpen}
-      >
+      <TooltipPrimitive.Root delayDuration={100} open={open} onOpenChange={onOpenChange} defaultOpen={defaultOpen}>
         {children}
       </TooltipPrimitive.Root>
     </TooltipPrimitive.Provider>
@@ -30,18 +16,10 @@ export const TooltipRoot = ({
 
 TooltipRoot.displayName = "Tooltip.Root";
 
-export const TooltipContent = ({
-  children,
-  label,
-  className,
-}: TooltipContentProps) => {
+export const TooltipContent = ({ children, label, className }: TooltipContentProps) => {
   return (
     <TooltipPrimitive.Portal>
-      <TooltipPrimitive.Content
-        sideOffset={5}
-        forceMount
-        className={cn(sharedTooltipStyles, className)}
-      >
+      <TooltipPrimitive.Content sideOffset={5} forceMount className={cn(sharedTooltipStyles, className)}>
         {label ? (
           <Text variant="body-small-200" noTranslations className="m-0 p-0">
             {label}

--- a/packages/ui/src/components/Tooltip/index.tsx
+++ b/packages/ui/src/components/Tooltip/index.tsx
@@ -38,24 +38,25 @@ const classnames = cn(
   "data-[state=delayed-open]:data-[side=bottom]:animate-slide-down-and-fade"
 );
 
-export const TooltipContent = ({ children, label }: TooltipContentProps) => {
+export const TooltipContent = ({
+  children,
+  label,
+  className,
+}: TooltipContentProps) => {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
         sideOffset={5}
-        asChild
         forceMount
-        className={classnames}
+        className={cn(classnames, className)}
       >
-        <div>
-          {label ? (
-            <Text variant="body-small-200" noTranslations className="m-0 p-0">
-              {label}
-            </Text>
-          ) : (
-            children
-          )}
-        </div>
+        {label ? (
+          <Text variant="body-small-200" noTranslations className="m-0 p-0">
+            {label}
+          </Text>
+        ) : (
+          children
+        )}
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/packages/ui/src/components/Tooltip/index.tsx
+++ b/packages/ui/src/components/Tooltip/index.tsx
@@ -6,6 +6,7 @@ import type {
   TooltipContentProps,
   TooltipTriggerProps,
 } from "./types";
+import { sharedTooltipStyles } from "./styles";
 
 export const TooltipRoot = ({
   children,
@@ -29,15 +30,6 @@ export const TooltipRoot = ({
 
 TooltipRoot.displayName = "Tooltip.Root";
 
-const classnames = cn(
-  "py-2 px-3 rounded-md bg-gray-700 text-white max-w-[200px]",
-  "will-change-[transform,opacity]",
-  "data-[state=delayed-open]:data-[side=top]:animate-slide-up-and-fade",
-  "data-[state=delayed-open]:data-[side=right]:animate-slide-right-and-fade",
-  "data-[state=delayed-open]:data-[side=left]:animate-slide-left-and-fade",
-  "data-[state=delayed-open]:data-[side=bottom]:animate-slide-down-and-fade"
-);
-
 export const TooltipContent = ({
   children,
   label,
@@ -48,7 +40,7 @@ export const TooltipContent = ({
       <TooltipPrimitive.Content
         sideOffset={5}
         forceMount
-        className={cn(classnames, className)}
+        className={cn(sharedTooltipStyles, className)}
       >
         {label ? (
           <Text variant="body-small-200" noTranslations className="m-0 p-0">

--- a/packages/ui/src/components/Tooltip/styles.ts
+++ b/packages/ui/src/components/Tooltip/styles.ts
@@ -1,10 +1,10 @@
 import { cn } from "../../utils/cn";
 
 export const sharedTooltipStyles = cn(
-	"py-2 px-3 rounded-md bg-gray-700 text-white max-w-[200px]",
-	"will-change-[transform,opacity]",
-	"data-[state=delayed-open]:data-[side=top]:animate-slide-up-and-fade",
-	"data-[state=delayed-open]:data-[side=right]:animate-slide-right-and-fade",
-	"data-[state=delayed-open]:data-[side=left]:animate-slide-left-and-fade",
-	"data-[state=delayed-open]:data-[side=bottom]:animate-slide-down-and-fade",
-); 
+  "py-2 px-3 rounded-md bg-gray-700 text-white max-w-[200px]",
+  "will-change-[transform,opacity]",
+  "data-[state=delayed-open]:data-[side=top]:animate-slide-up-and-fade",
+  "data-[state=delayed-open]:data-[side=right]:animate-slide-right-and-fade",
+  "data-[state=delayed-open]:data-[side=left]:animate-slide-left-and-fade",
+  "data-[state=delayed-open]:data-[side=bottom]:animate-slide-down-and-fade",
+);

--- a/packages/ui/src/components/Tooltip/styles.ts
+++ b/packages/ui/src/components/Tooltip/styles.ts
@@ -1,0 +1,10 @@
+import { cn } from "../../utils/cn";
+
+export const sharedTooltipStyles = cn(
+	"py-2 px-3 rounded-md bg-gray-700 text-white max-w-[200px]",
+	"will-change-[transform,opacity]",
+	"data-[state=delayed-open]:data-[side=top]:animate-slide-up-and-fade",
+	"data-[state=delayed-open]:data-[side=right]:animate-slide-right-and-fade",
+	"data-[state=delayed-open]:data-[side=left]:animate-slide-left-and-fade",
+	"data-[state=delayed-open]:data-[side=bottom]:animate-slide-down-and-fade",
+); 

--- a/packages/ui/src/components/Tooltip/types.ts
+++ b/packages/ui/src/components/Tooltip/types.ts
@@ -1,0 +1,21 @@
+export type TooltipRootProps = {
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+};
+
+export type TooltipContentProps = {
+  children?: React.ReactNode;
+  label?: string;
+};
+
+export type TooltipTriggerProps = {
+  children: React.ReactNode;
+};
+
+export type TooltipProps = {
+  Root: TooltipRootProps;
+  Content: TooltipContentProps;
+  Trigger: TooltipTriggerProps;
+};

--- a/packages/ui/src/components/Tooltip/types.ts
+++ b/packages/ui/src/components/Tooltip/types.ts
@@ -8,6 +8,7 @@ export type TooltipRootProps = {
 export type TooltipContentProps = {
   children?: React.ReactNode;
   label?: string;
+  className?: string;
 };
 
 export type TooltipTriggerProps = {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -23,6 +23,10 @@ export { Text } from "./components/Text";
 export * from "./components/Text/types";
 export type { TextProps } from "./components/Text/types";
 
+export { Tooltip } from "./components/Tooltip";
+export * from "./components/Tooltip/types";
+export type { TooltipProps } from "./components/Tooltip/types";
+
 export * from "./designSystemTokens";
 
 export { shadcnPreset } from "./tailwind/shadcn-preset";

--- a/packages/ui/src/tailwind/shadcn-plugin.ts
+++ b/packages/ui/src/tailwind/shadcn-plugin.ts
@@ -147,6 +147,22 @@ export const shadcnPlugin = plugin(
               transform: "translateY(0px)",
             },
           },
+          "slide-down-and-fade": {
+            from: { opacity: "0", transform: "translateY(-5px)" },
+            to: { opacity: "1", transform: "translateY(0)" },
+          },
+          "slide-left-and-fade": {
+            from: { opacity: "0", transform: "translateX(5px)" },
+            to: { opacity: "1", transform: "translateX(0)" },
+          },
+          "slide-up-and-fade": {
+            from: { opacity: "0", transform: "translateY(5px)" },
+            to: { opacity: "1", transform: "translateY(0)" },
+          },
+          "slide-right-and-fade": {
+            from: { opacity: "0", transform: "translateX(-5px)" },
+            to: { opacity: "1", transform: "translateX(0)" },
+          },
           "accordion-down": {
             from: { height: "0" },
             to: { height: "var(--radix-accordion-content-height)" },
@@ -161,8 +177,12 @@ export const shadcnPlugin = plugin(
           "fade-down": "fade-down 0.5s",
           "accordion-down": "accordion-down 0.2s ease-out",
           "accordion-up": "accordion-up 0.2s ease-out",
+          "slide-down-and-fade": "slide-down-and-fade 0.2s ease-out",
+          "slide-up-and-fade": "slide-up-and-fade 0.2s ease-out",
+          "slide-left-and-fade": "slide-left-and-fade 0.2s ease-out",
+          "slide-right-and-fade": "slide-right-and-fade 0.2s ease-out",
         },
       },
     },
-  },
+  }
 );

--- a/packages/ui/src/tailwind/shadcn-plugin.ts
+++ b/packages/ui/src/tailwind/shadcn-plugin.ts
@@ -184,5 +184,5 @@ export const shadcnPlugin = plugin(
         },
       },
     },
-  }
+  },
 );

--- a/packages/ui/vite.config.plugin.ts
+++ b/packages/ui/vite.config.plugin.ts
@@ -14,6 +14,7 @@ export default defineConfig({
         "@biomejs/biome",
         "@radix-ui/react-checkbox",
         "@radix-ui/react-slot",
+        "@radix-ui/react-tooltip",
         "@tailwindcss/typography",
         "@types/fs-extra",
         "@types/node",

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
         "@biomejs/biome",
         "@radix-ui/react-checkbox",
         "@radix-ui/react-slot",
+        "@radix-ui/react-tooltip",
         "@tailwindcss/typography",
         "@types/fs-extra",
         "@types/node",


### PR DESCRIPTION
#### This PR:
- Introduces `radix-ui/react-tooltip` dependency
- Introduces new `Tooltip` component
- Adds storybook stories for `Tooltip` component
- Make sure Postcss exports default for storybook

#### UI:

https://github.com/user-attachments/assets/5e6e64d1-b178-4928-9f53-6376c70dd975


#### Note: 

Tried to allow overiding tooltip content but postcss export was off, removing `css rules` from the loaded styles. You could see the `tw classNames` existed in an element but the corresponding styles were not there.
After changing that I made some minor changes for the overiding logic and added a story that showcases it.

