### PR TITLE
Add shadcn charts in symbiosis

### DIFF
--- a/examples/storybook/src/stories/CustomChart.stories.tsx
+++ b/examples/storybook/src/stories/CustomChart.stories.tsx
@@ -1,0 +1,145 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Chart, type ChartConfig } from "@synopsisapp/symbiosis-ui";
+
+const meta: Meta<typeof Chart.Container> = {
+  title: "Components/Custom chart",
+  component: Chart.Container,
+  tags: ["autodocs"],
+} satisfies Meta<typeof Chart.Container>;
+
+export default meta;
+
+type Story = StoryObj<typeof Chart.Container>;
+
+const chartData = [
+  { date: "2024-04-01", desktop: 222, mobile: 150 },
+  { date: "2024-04-02", desktop: 97, mobile: 180 },
+  { date: "2024-04-03", desktop: 167, mobile: 120 },
+  { date: "2024-04-04", desktop: 242, mobile: 260 },
+  { date: "2024-04-05", desktop: 373, mobile: 290 },
+  { date: "2024-04-06", desktop: 301, mobile: 340 },
+  { date: "2024-04-07", desktop: 245, mobile: 180 },
+  { date: "2024-04-08", desktop: 409, mobile: 320 },
+  { date: "2024-04-09", desktop: 59, mobile: 110 },
+  { date: "2024-04-10", desktop: 261, mobile: 190 },
+  { date: "2024-04-11", desktop: 327, mobile: 350 },
+  { date: "2024-04-12", desktop: 292, mobile: 210 },
+  { date: "2024-04-13", desktop: 342, mobile: 380 },
+  { date: "2024-04-14", desktop: 137, mobile: 220 },
+  { date: "2024-04-15", desktop: 120, mobile: 170 },
+  { date: "2024-04-16", desktop: 138, mobile: 190 },
+  { date: "2024-04-17", desktop: 446, mobile: 360 },
+  { date: "2024-04-18", desktop: 364, mobile: 410 },
+  { date: "2024-04-19", desktop: 243, mobile: 180 },
+  { date: "2024-04-20", desktop: 89, mobile: 150 },
+  { date: "2024-04-21", desktop: 137, mobile: 200 },
+];
+
+const chartConfig = {
+  desktop: { label: "Desktop", color: "bg-yellow-500" },
+  mobile: { label: "Mobile", color: "#890089" },
+} satisfies ChartConfig;
+
+type ChartDataPoint = Record<string, number | string>;
+
+const generateDefs = <T extends ChartDataPoint>(chartData: T[], chartConfig: ChartConfig) => {
+  if (chartData.length === 0) return null;
+
+  const dataKeys = Object.keys(chartData[0]).filter((key) => key !== "date" && typeof chartData[0][key] === "number");
+
+  return (
+    <defs>
+      {dataKeys
+        .map((key) => {
+          if (chartConfig[key]) {
+            return (
+              <linearGradient
+                key={key}
+                id={`fill${key.charAt(0).toUpperCase() + key.slice(1)}`}
+                x1="0"
+                y1="0"
+                x2="0"
+                y2="1"
+              >
+                <stop offset="5%" stopColor={`var(--color-${key})`} stopOpacity={0.8} />
+                <stop offset="95%" stopColor={`var(--color-${key})`} stopOpacity={0.1} />
+              </linearGradient>
+            );
+          }
+          return null;
+        })
+        .filter(Boolean)}
+    </defs>
+  );
+};
+
+const generateAreas = <T extends ChartDataPoint>(chartData: T[], chartConfig: ChartConfig) => {
+  if (chartData.length === 0) return [];
+
+  const dataKeys = Object.keys(chartData[0]).filter((key) => key !== "date" && typeof chartData[0][key] === "number");
+
+  return dataKeys
+    .map((key) => {
+      if (chartConfig[key]) {
+        return (
+          <Chart.Area
+            key={key}
+            dataKey={key}
+            type="natural"
+            fill={`url(#fill${key.charAt(0).toUpperCase() + key.slice(1)})`}
+            stroke={`var(--color-${key})`}
+            stackId="a"
+          />
+        );
+      }
+      return null;
+    })
+    .filter(Boolean);
+};
+
+export const Default: Story = {
+  render: (args) => {
+    return (
+      <Chart.Container {...args} config={chartConfig} className="aspect-auto h-[250px] w-full">
+        <Chart.AreaChart data={chartData}>
+          {generateDefs(chartData, chartConfig)}
+
+          <Chart.CartesianGrid vertical={false} />
+          <Chart.XAxis
+            dataKey="date"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            minTickGap={32}
+            tickFormatter={(value) => {
+              const date = new Date(value);
+              return date.toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+              });
+            }}
+          />
+          <Chart.Tooltip
+            cursor={false}
+            content={
+              <Chart.TooltipContent
+                labelFormatter={(value) => {
+                  return new Date(value).toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                  });
+                }}
+                indicator="dot"
+              />
+            }
+          />
+          {generateAreas(chartData, chartConfig)}
+          <Chart.Legend content={<Chart.LegendContent />} />
+        </Chart.AreaChart>
+      </Chart.Container>
+    );
+  },
+};
+
+

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -52,6 +52,7 @@
     "lucide-react": "^0.383.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "recharts": "^2.12.7",
     "tailwindcss": "^3.3.2",
     "tailwindcss-animate": "^1.0.6",
     "zod": "^3.23.8",

--- a/packages/ui/src/components/Charts/constants.ts
+++ b/packages/ui/src/components/Charts/constants.ts
@@ -1,0 +1,1 @@
+export const THEMES = { light: "", dark: ".dark" } as const;

--- a/packages/ui/src/components/Charts/helpers/getPayloadConfigFromPayload.ts
+++ b/packages/ui/src/components/Charts/helpers/getPayloadConfigFromPayload.ts
@@ -1,0 +1,26 @@
+import type { ChartConfig } from "../types";
+
+export function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key: string) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined;
+  }
+
+  const payloadPayload =
+    "payload" in payload && typeof payload.payload === "object" && payload.payload !== null
+      ? payload.payload
+      : undefined;
+
+  let configLabelKey: string = key;
+
+  if (key in payload && typeof payload[key as keyof typeof payload] === "string") {
+    configLabelKey = payload[key as keyof typeof payload] as string;
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[key as keyof typeof payloadPayload] as string;
+  }
+
+  return configLabelKey in config ? config[configLabelKey] : config[key as keyof typeof config];
+}

--- a/packages/ui/src/components/Charts/helpers/getPayloadConfigFromPayload.ts
+++ b/packages/ui/src/components/Charts/helpers/getPayloadConfigFromPayload.ts
@@ -1,26 +1,22 @@
 import type { ChartConfig } from "../types";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key: string) {
-  if (typeof payload !== "object" || payload === null) {
+  if (!isRecord(payload)) {
     return undefined;
   }
 
-  const payloadPayload =
-    "payload" in payload && typeof payload.payload === "object" && payload.payload !== null
-      ? payload.payload
-      : undefined;
+  const payloadPayload = isRecord(payload.payload) ? payload.payload : undefined;
 
-  let configLabelKey: string = key;
+  const configLabelKey =
+    typeof payload[key] === "string"
+      ? payload[key]
+      : payloadPayload && typeof payloadPayload[key] === "string"
+        ? payloadPayload[key]
+        : key;
 
-  if (key in payload && typeof payload[key as keyof typeof payload] === "string") {
-    configLabelKey = payload[key as keyof typeof payload] as string;
-  } else if (
-    payloadPayload &&
-    key in payloadPayload &&
-    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
-  ) {
-    configLabelKey = payloadPayload[key as keyof typeof payloadPayload] as string;
-  }
-
-  return configLabelKey in config ? config[configLabelKey] : config[key as keyof typeof config];
+  return config[configLabelKey as keyof ChartConfig] ?? config[key as keyof ChartConfig];
 }

--- a/packages/ui/src/components/Charts/helpers/index.ts
+++ b/packages/ui/src/components/Charts/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from "./getPayloadConfigFromPayload";

--- a/packages/ui/src/components/Charts/hooks/useChart.ts
+++ b/packages/ui/src/components/Charts/hooks/useChart.ts
@@ -1,0 +1,20 @@
+import * as React from "react";
+import type { ChartConfig } from "../types";
+
+type ChartContextProps = {
+  config: ChartConfig;
+};
+
+const ChartContext = React.createContext<ChartContextProps | null>(null);
+
+export const useChart = () => {
+  const context = React.useContext(ChartContext);
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />");
+  }
+
+  return context;
+};
+
+export { ChartContext };

--- a/packages/ui/src/components/Charts/index.tsx
+++ b/packages/ui/src/components/Charts/index.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import * as React from "react";
+import * as ChartPrimitive from "recharts";
+
+import type { ChartConfig } from "./types";
+import { ChartContext, useChart } from "./hooks/useChart";
+import { getPayloadConfigFromPayload } from "./helpers/getPayloadConfigFromPayload";
+import { cn } from "../../utils/cn";
+import { THEMES } from "./constants";
+import { Text } from "../Text";
+
+const ChartContainer = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div"> & {
+    config: ChartConfig;
+    children: React.ComponentProps<typeof ChartPrimitive.ResponsiveContainer>["children"];
+  }
+>(({ id, className, children, config, ...props }, ref) => {
+  const uniqueId = React.useId();
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`;
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-chart={chartId}
+        ref={ref}
+        className={cn(
+          "flex aspect-video justify-center text-xs [&_recharts-cartesian-axis]:font-[inherit] [&_.recharts-cartesian-axis-tick_text]:fill-slate-600/60 [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-slate-300/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          className,
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <ChartPrimitive.ResponsiveContainer>{children}</ChartPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  );
+});
+
+ChartContainer.displayName = "Chart";
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(([_, config]) => config.theme || config.color);
+
+  if (!colorConfig.length) {
+    return null;
+  }
+
+  return (
+    <style
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: It's on purpose
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color = itemConfig.theme?.[theme as keyof typeof itemConfig.theme] || itemConfig.color;
+    return color ? `  --color-${key}: ${color};` : null;
+  })
+  .join("\n")}
+}
+`,
+          )
+          .join("\n"),
+      }}
+    />
+  );
+};
+
+const ChartTooltipContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<typeof ChartPrimitive.Tooltip> &
+    React.ComponentProps<"div"> & {
+      hideLabel?: boolean;
+      hideIndicator?: boolean;
+      indicator?: "line" | "dot" | "dashed";
+      nameKey?: string;
+      labelKey?: string;
+    }
+>(
+  (
+    {
+      active,
+      payload,
+      className,
+      indicator = "dot",
+      hideLabel = false,
+      hideIndicator = false,
+      label,
+      labelFormatter,
+      labelClassName,
+      formatter,
+      color,
+      nameKey,
+      labelKey,
+    },
+    ref,
+  ) => {
+    const { config } = useChart();
+
+    const tooltipLabel = React.useMemo(() => {
+      if (hideLabel || !payload?.length) {
+        return null;
+      }
+
+      const [item] = payload;
+      const key = `${labelKey || item.dataKey || item.name || "value"}`;
+      const itemConfig = getPayloadConfigFromPayload(config, item, key);
+      const value =
+        !labelKey && typeof label === "string"
+          ? config[label as keyof typeof config]?.label || label
+          : itemConfig?.label;
+
+      if (labelFormatter) {
+        return <div className={cn("font-medium", labelClassName)}>{labelFormatter(value, payload)}</div>;
+      }
+
+      if (!value) {
+        return null;
+      }
+
+      return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+    }, [label, labelFormatter, payload, hideLabel, labelClassName, config, labelKey]);
+
+    if (!active || !payload?.length) {
+      return null;
+    }
+
+    const nestLabel = payload.length === 1 && indicator !== "dot";
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-slate-600/20 bg-white px-2.5 py-1.5 text-xs shadow-xl text-slate-600",
+          className,
+        )}
+      >
+        {!nestLabel ? tooltipLabel : null}
+        <div className="grid gap-1.5">
+          {payload.map((item, index) => {
+            const key = `${nameKey || item.name || item.dataKey || "value"}`;
+            const itemConfig = getPayloadConfigFromPayload(config, item, key);
+            const indicatorColor = color || item.payload.fill || item.color;
+
+            return (
+              <div
+                key={item.dataKey}
+                className={cn(
+                  "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-inherit",
+                  indicator === "dot" && "items-center",
+                )}
+              >
+                {formatter && item?.value !== undefined && item.name ? (
+                  formatter(item.value, item.name, item, index, item.payload)
+                ) : (
+                  <>
+                    {itemConfig?.icon ? (
+                      <itemConfig.icon />
+                    ) : (
+                      !hideIndicator && (
+                        <div
+                          className={cn("shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]", {
+                            "h-2.5 w-2.5": indicator === "dot",
+                            "w-1": indicator === "line",
+                            "w-0 border-[1.5px] border-dashed bg-transparent": indicator === "dashed",
+                            "my-0.5": nestLabel && indicator === "dashed",
+                          })}
+                          style={
+                            {
+                              "--color-bg": indicatorColor,
+                              "--color-border": indicatorColor,
+                            } as React.CSSProperties
+                          }
+                        />
+                      )
+                    )}
+                    <div
+                      className={cn(
+                        "flex flex-1 justify-between leading-none text-inherit",
+                        nestLabel ? "items-end" : "items-center",
+                      )}
+                    >
+                      <div className="grid gap-1.5">
+                        {nestLabel && (
+                          <Text variant="body-small-200" renderAs="span" className="text-inherit my-0">
+                            {tooltipLabel}
+                          </Text>
+                        )}
+                        <Text variant="body-small-200" renderAs="span" weight="thin-100" className="text-inherit my-0">
+                          {itemConfig?.label || item.name}
+                        </Text>
+                      </div>
+                      {item.value && (
+                        <Text variant="body-small-200" renderAs="span" className="tabular-nums text-inherit my-0">
+                          {item.value.toLocaleString()}
+                        </Text>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  },
+);
+
+ChartTooltipContent.displayName = "ChartTooltip";
+
+const ChartLegendContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div"> &
+    Pick<ChartPrimitive.LegendProps, "payload" | "verticalAlign"> & {
+      hideIcon?: boolean;
+      nameKey?: string;
+    }
+>(({ className, hideIcon = false, payload, verticalAlign = "bottom", nameKey }, ref) => {
+  const { config } = useChart();
+
+  if (!payload?.length) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "flex items-center justify-center gap-4 text-slate-600",
+        verticalAlign === "top" ? "pb-3" : "pt-3",
+        className,
+      )}
+    >
+      {payload.map((item) => {
+        const key = `${nameKey || item.dataKey || "value"}`;
+        const itemConfig = getPayloadConfigFromPayload(config, item, key);
+
+        return (
+          <div
+            key={item.value}
+            className={cn("flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-inherit")}
+          >
+            {itemConfig?.icon && !hideIcon ? (
+              <itemConfig.icon />
+            ) : (
+              <div
+                className="h-2 w-2 shrink-0 rounded-[2px]"
+                style={{
+                  backgroundColor: item.color,
+                }}
+              />
+            )}
+            <Text variant="body-small-200" className="text-inherit my-0">
+              {itemConfig?.label}
+            </Text>
+          </div>
+        );
+      })}
+    </div>
+  );
+});
+
+ChartLegendContent.displayName = "ChartLegend";
+
+type ChartType = typeof ChartPrimitive & {
+  Container: typeof ChartContainer;
+  TooltipContent: typeof ChartTooltipContent;
+  LegendContent: typeof ChartLegendContent;
+  Style: typeof ChartStyle;
+};
+
+export const Chart: ChartType = {
+  Container: ChartContainer,
+  TooltipContent: ChartTooltipContent,
+  LegendContent: ChartLegendContent,
+  Style: ChartStyle,
+  ...ChartPrimitive,
+};

--- a/packages/ui/src/components/Charts/index.tsx
+++ b/packages/ui/src/components/Charts/index.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import * as ChartPrimitive from "recharts";
+import { getTwColor } from "../../utils/getTwColor";
 
 import type { ChartConfig } from "./types";
 import { ChartContext, useChart } from "./hooks/useChart";
@@ -58,8 +59,9 @@ ${prefix} [data-chart=${id}] {
 ${colorConfig
   .map(([key, itemConfig]) => {
     const color = itemConfig.theme?.[theme as keyof typeof itemConfig.theme] || itemConfig.color;
-    return color ? `  --color-${key}: ${color};` : null;
+    return color ? `  --color-${key}: ${getTwColor(color)};` : null;
   })
+  .filter(Boolean)
   .join("\n")}
 }
 `,

--- a/packages/ui/src/components/Charts/types.ts
+++ b/packages/ui/src/components/Charts/types.ts
@@ -1,0 +1,10 @@
+import type { THEMES } from "./constants";
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode;
+    icon?: React.ComponentType;
+  } & ({ color?: string; theme?: never } | { color?: never; theme: Record<keyof typeof THEMES, string> });
+};
+
+export type * from "recharts";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,7 @@
 import "./tailwind.css";
 
 export { cn } from "./utils/cn";
+export { getTwColor } from "./utils/getTwColor";
 
 export { Button } from "./components/Button";
 export * from "./components/Button/types";
@@ -31,3 +32,8 @@ export * from "./designSystemTokens";
 
 export { shadcnPreset } from "./tailwind/shadcn-preset";
 export { shadcnPlugin } from "./tailwind/shadcn-plugin";
+
+export { Chart } from "./components/Charts";
+export * from "./components/Charts/types";
+export type { ChartConfig } from "./components/Charts/types";
+export * from "./components/Charts/helpers";

--- a/packages/ui/src/tailwind/shadcn-plugin.ts
+++ b/packages/ui/src/tailwind/shadcn-plugin.ts
@@ -27,6 +27,11 @@ export const shadcnPlugin = plugin(
         "--destructive-foreground": "210 40% 98%",
         "--ring": "215 20.2% 65.1%",
         "--radius": "0.5rem",
+        "--chart-1": "12 76% 61%",
+        "--chart-2": "173 58% 39%",
+        "--chart-3": "197 37% 24%",
+        "--chart-4": "43 74% 66%",
+        "--chart-5": "27 87% 67%",
       },
       ".dark": {
         colorScheme: "dark",
@@ -50,6 +55,11 @@ export const shadcnPlugin = plugin(
         "--destructive-foreground": "210 40% 98%",
         "--ring": "216 34% 17%",
         "--radius": "0.5rem",
+        "--chart-1": "220 70% 50%",
+        "--chart-2": "160 60% 45%",
+        "--chart-3": "30 80% 55%",
+        "--chart-4": "280 65% 60%",
+        "--chart-5": "340 75% 55%",
       },
     });
 

--- a/packages/ui/src/utils/getTwColor.ts
+++ b/packages/ui/src/utils/getTwColor.ts
@@ -1,0 +1,19 @@
+import colors from "tailwindcss/colors";
+
+export function getTwColor(color: string): string {
+  if (color.startsWith("bg-") || color.startsWith("text-")) {
+    const [prefix, colorName, shade] = color.split("-");
+
+    if (colorName in colors) {
+      const colorSet = colors[colorName as keyof typeof colors];
+      if (typeof colorSet === "string") {
+        return colorSet;
+      }
+      if (typeof colorSet === "object" && shade in colorSet) {
+        return colorSet[shade as keyof typeof colorSet];
+      }
+    }
+  }
+
+  return color;
+}


### PR DESCRIPTION
#### This PR:

- Adds `recharts` peer dependency 
- Adds a `getTwColor` util function that allows us to get hex codes from tw color classes.
- Adds shadcn charts utils, constants, contexts and the groundwork in general
- Adds the recharts extensions from shadcn that also use `getTwColor`.
- Exports recharts extensions alongside recharts.

#### UI:

https://github.com/user-attachments/assets/2684780e-72d6-4168-bcf3-fa457a867f76

