### PR TITLE
Fix Tooltip styling for charts

### DIFF
--- a/examples/storybook/src/stories/SymbiosisAreaChart.stories.tsx
+++ b/examples/storybook/src/stories/SymbiosisAreaChart.stories.tsx
@@ -1032,6 +1032,7 @@ export const CustomUI: Story = {
         {...args}
         className="bg-slate-400 [&_.recharts-cartesian-axis-tick_text]:fill-white [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-white"
         legendClassName="text-white"
+        tooltipClassName="rounded-none border-green-400 border-2"
       />
     );
   },

--- a/packages/ui/src/components/Charts/index.tsx
+++ b/packages/ui/src/components/Charts/index.tsx
@@ -182,7 +182,7 @@ const ChartTooltipContent = React.forwardRef<
                     )}
                     <div
                       className={cn(
-                        "flex flex-1 justify-between leading-none text-inherit",
+                        "flex flex-1 justify-between leading-none text-inherit gap-2",
                         nestLabel ? "items-end" : "items-center",
                       )}
                     >

--- a/packages/ui/src/components/SymbiosisAreaChart/index.tsx
+++ b/packages/ui/src/components/SymbiosisAreaChart/index.tsx
@@ -12,6 +12,7 @@ const SymbiosisAreaChart = ({
   tooltipLabelFormatter,
   className,
   legendClassName,
+  tooltipClassName,
 }: SymbiosisAreaChartProps) => {
   const defaultTickFormatter = React.useCallback((value: string) => {
     const date = new Date(value);
@@ -48,6 +49,7 @@ const SymbiosisAreaChart = ({
             <Chart.TooltipContent
               labelFormatter={tooltipLabelFormatter ?? defaultTooltipLabelFormatter}
               indicator="dot"
+              className={tooltipClassName}
             />
           }
         />

--- a/packages/ui/src/components/SymbiosisAreaChart/types.tsx
+++ b/packages/ui/src/components/SymbiosisAreaChart/types.tsx
@@ -7,4 +7,5 @@ export type SymbiosisAreaChartProps = {
   tooltipLabelFormatter?: (value: string) => string;
   className?: string;
   legendClassName?: string;
+  tooltipClassName?: string;
 };


### PR DESCRIPTION
#### This PR:
- Adds a default gap of `0.5rem` in the label-value flex of the tooltip, to allow really big labels to render nicely.
- Adds a `tooltipClassname` optional prop to `SymbiosisAreaChart`, to allow tooltip style overrides
- Enhances `SymbiosisAreaChart` storybook stories to showcase the new prop.

#### The UI:

<img width="1079" alt="image" src="https://github.com/user-attachments/assets/bc71ad16-caab-4979-849d-c1c0f5227150">
<img width="865" alt="Screenshot 2024-09-12 at 2 06 03 PM" src="https://github.com/user-attachments/assets/3336f65c-9151-4932-bde2-3a7964a8b9c7">
