### PR TITLE
Add year to default tooltip formatter of symbiosis area chart

### DIFF
--- a/packages/ui/src/components/SymbiosisAreaChart/index.tsx
+++ b/packages/ui/src/components/SymbiosisAreaChart/index.tsx
@@ -27,6 +27,7 @@ const SymbiosisAreaChart = ({
     return date.toLocaleDateString("en-US", {
       month: "short",
       day: "numeric",
+      year: "numeric",
     });
   }, []);
 


### PR DESCRIPTION
#### This PR:
Adds the year to the default tooltip formatter of the `SymbiosisAreaChart` component.


<img width="819" alt="Screenshot 2024-09-27 at 6 14 34 PM" src="https://github.com/user-attachments/assets/c2479c43-e631-4d5d-b71d-19248d3cbf8e">
