### PR TITLE
Updates the way we handle stickyness for checkboxes on DataTables.

### DIFF
--- a/examples/storybook/src/stories/DataTable.stories.tsx
+++ b/examples/storybook/src/stories/DataTable.stories.tsx
@@ -245,6 +245,7 @@ export const WithPinningAndStickyHeader: Story = {
     ...Default.args,
     pinningState: {
       left: ["name"],
+      right: ["actions"],
     },
     isSelectable: true,
     stickyHeader: true,
@@ -320,5 +321,3 @@ const ControlledDataTable = () => {
     },
   },
 };
-
-

--- a/packages/ui/src/components/DataTable/index.tsx
+++ b/packages/ui/src/components/DataTable/index.tsx
@@ -256,9 +256,9 @@ const DataTable = <TData, TValue>({
   React.useEffect(() => {
     if (!pinningState) return;
 
-    if (isSelectable && !!pinningState?.left) {
+    if (isSelectable) {
       const updatedPinningState = { ...pinningState };
-      updatedPinningState.left = ["select", ...pinningState.left];
+      updatedPinningState.left = ["select", ...(pinningState.left ?? [])];
       table.setColumnPinning(updatedPinningState);
       return;
     }

--- a/packages/ui/src/components/DataTable/styles.ts
+++ b/packages/ui/src/components/DataTable/styles.ts
@@ -20,7 +20,7 @@ export const tableCellStyles = cva("sticky z-20 transition-colors pl-[22px]", {
       false: "",
     },
     isSecondColumn: {
-      true: "left-10",
+      true: "",
       false: "",
     },
   },
@@ -29,6 +29,7 @@ export const tableCellStyles = cva("sticky z-20 transition-colors pl-[22px]", {
       pinedPosition: "left",
       isSelectable: true,
       isSecondColumn: true,
+      className: "left-10",
     },
   ],
   defaultVariants: {


### PR DESCRIPTION
Updates cva Styling rules for sticky columns when checkboxes are active. Updates Story with StickyHeader/Column DataTable to facilitate both left & right sticky columns