### PR TITLE
Add breadcrumb component

### DIFF
--- a/examples/storybook/src/stories/Breadcrumb.stories.tsx
+++ b/examples/storybook/src/stories/Breadcrumb.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  Breadcrumb,
+} from "@synopsisapp/symbiosis-ui";
+
+const meta: Meta = {
+  title: "Components/Breadcrumb",
+  component: Breadcrumb.Root,
+  tags: ["autodocs"],
+};
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: (args) => (
+    <Breadcrumb.Root {...args}>
+      <Breadcrumb.List>
+        <Breadcrumb.Item>
+          <Breadcrumb.Link href="#home">Home</Breadcrumb.Link>
+        </Breadcrumb.Item>
+        <Breadcrumb.Separator />
+        <Breadcrumb.Item>
+          <Breadcrumb.Link href="#library">Library</Breadcrumb.Link>
+        </Breadcrumb.Item>
+        <Breadcrumb.Separator />
+        <Breadcrumb.Item>
+          <Breadcrumb.Page>Data</Breadcrumb.Page>
+        </Breadcrumb.Item>
+      </Breadcrumb.List>
+    </Breadcrumb.Root>
+  ),
+  args: {},
+};
+export const DefaultWithoutLinks: Story = {
+  render: (args) => (
+    <Breadcrumb.Root {...args}>
+      <Breadcrumb.List>
+        <Breadcrumb.Item>
+          <span>Home</span>
+        </Breadcrumb.Item>
+        <Breadcrumb.Separator />
+        <Breadcrumb.Item>
+          <span>Library</span>
+        </Breadcrumb.Item>
+        <Breadcrumb.Separator />
+        <Breadcrumb.Item>
+          <Breadcrumb.Page>Data</Breadcrumb.Page>
+        </Breadcrumb.Item>
+      </Breadcrumb.List>
+    </Breadcrumb.Root>
+  ),
+};
+
+export const CustomSeparator: Story = {
+  render: () => (
+    <Breadcrumb.Root>
+      <Breadcrumb.List>
+        <Breadcrumb.Item>
+          <Breadcrumb.Link href="#home">Home</Breadcrumb.Link>
+        </Breadcrumb.Item>
+        <Breadcrumb.Separator>
+          <span> / </span>
+        </Breadcrumb.Separator>
+        <Breadcrumb.Item>
+          <Breadcrumb.Link href="#library">Library</Breadcrumb.Link>
+        </Breadcrumb.Item>
+        <Breadcrumb.Separator>
+          <span> / </span>
+        </Breadcrumb.Separator>
+        <Breadcrumb.Item>
+          <Breadcrumb.Page>Data</Breadcrumb.Page>
+        </Breadcrumb.Item>
+      </Breadcrumb.List>
+    </Breadcrumb.Root>
+  ),
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -24680,7 +24680,7 @@
     },
     "packages/ui": {
       "name": "@synopsisapp/symbiosis-ui",
-      "version": "0.0.17",
+      "version": "0.0.20",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.17.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24680,7 +24680,7 @@
     },
     "packages/ui": {
       "name": "@synopsisapp/symbiosis-ui",
-      "version": "0.0.20",
+      "version": "0.0.19",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.17.7",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synopsisapp/symbiosis-ui",
-  "version": "0.0.18",
+  "version": "0.0.20",
   "license": "MIT",
   "type": "module",
   "main": "dist/symbiosis-ui.umd.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synopsisapp/symbiosis-ui",
-  "version": "0.0.20",
+  "version": "0.0.19",
   "license": "MIT",
   "type": "module",
   "main": "dist/symbiosis-ui.umd.js",

--- a/packages/ui/src/components/Breadcrumb/index.tsx
+++ b/packages/ui/src/components/Breadcrumb/index.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { Icon } from "../Icon";
+import { text } from "../Text/styles";
+import { cn } from "../../utils/cn";
+
+const BreadcrumbRoot = React.forwardRef<HTMLElement, React.ComponentPropsWithoutRef<"nav">>(({ ...props }, ref) => (
+  <nav ref={ref} aria-label="breadcrumb" {...props} />
+));
+BreadcrumbRoot.displayName = "Breadcrumb.Root";
+
+const BreadcrumbList = React.forwardRef<HTMLOListElement, React.ComponentPropsWithoutRef<"ol">>(
+  ({ className, ...props }, ref) => (
+    <ol
+      ref={ref}
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 break-words text-gray-400 sm:gap-2.5",
+        text({ variant: "body-small-100" }),
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+
+BreadcrumbList.displayName = "Breadcrumb.List";
+
+const BreadcrumbItem = React.forwardRef<HTMLLIElement, React.ComponentPropsWithoutRef<"li">>(
+  ({ className, ...props }, ref) => (
+    <li ref={ref} className={cn("inline-flex items-center gap-1.5", className)} {...props} />
+  ),
+);
+BreadcrumbItem.displayName = "Breadcrumb.Item";
+
+const BreadcrumbLink = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentPropsWithoutRef<"a"> & {
+    asChild?: boolean;
+  }
+>(({ asChild, className, ...props }, ref) => {
+  const Comp = asChild ? Slot : "a";
+
+  return <Comp ref={ref} className={cn("transition-colors hover:text-mainColors-base", className)} {...props} />;
+});
+BreadcrumbLink.displayName = "Breadcrumb.Link";
+
+const BreadcrumbPage = React.forwardRef<HTMLSpanElement, React.ComponentPropsWithoutRef<"span">>(
+  ({ className, ...props }, ref) => (
+    <span
+      ref={ref}
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn("text-black", text({ weight: "base" }), className)}
+      {...props}
+    />
+  ),
+);
+BreadcrumbPage.displayName = "Breadcrumb.Page";
+
+const BreadcrumbSeparator = ({ children, className, ...props }: React.ComponentProps<"li">) => (
+  <li role="presentation" aria-hidden="true" className={cn("[&>svg]:size-3.5", className)} {...props}>
+    {children ?? <Icon name="symbiosis-chevron-right" />}
+  </li>
+);
+BreadcrumbSeparator.displayName = "Breadcrumb.Separator";
+
+export const Breadcrumb = {
+  Root: BreadcrumbRoot,
+  List: BreadcrumbList,
+  Item: BreadcrumbItem,
+  Link: BreadcrumbLink,
+  Page: BreadcrumbPage,
+  Separator: BreadcrumbSeparator,
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -123,3 +123,5 @@ export type { DateRangeFieldProps } from "./components/DateRangeField/types";
 export { getPayloadConfigFromPayload } from "./helpers/getPayloadConfigFromPayload";
 export { calculateCountForDataOnDates } from "./helpers/calculateCountForDataOnDates";
 export { getDateFormat } from "./helpers/getDateFormat";
+
+export { Breadcrumb } from './components/Breadcrumb';


### PR DESCRIPTION
**This PR:**
- Implements Breadcrumb component based on Shadcn UI [here](https://ui.shadcn.com/docs/components/breadcrumb)
- Adds storybook stories to showcase Breadcrumb component

**Sneak peek of the UI:**
<img width="570" alt="Screenshot 2025-01-08 at 14 20 04" src="https://github.com/user-attachments/assets/d16822a0-fc0c-4ea5-ab82-9f02bc813bd3" />
