### PR TITLE
Fixes for datefield components

### DIFF
--- a/examples/storybook/src/stories/DateRangeField.stories.tsx
+++ b/examples/storybook/src/stories/DateRangeField.stories.tsx
@@ -8,11 +8,22 @@ const meta: Meta<DateRangeFieldProps> = {
   component: DateRangeField,
   tags: ["autodocs"],
   argTypes: {
-    label: {
+    labelFrom: {
       control: {
         type: "text",
       },
-      description: "Label for the DateRangeField",
+      description: "Label for the DateRangeField from",
+      table: {
+        type: {
+          summary: "string",
+        },
+      },
+    },
+    labelTo: {
+      control: {
+        type: "text",
+      },
+      description: "Label for the DateRangeField to",
       table: {
         type: {
           summary: "string",
@@ -127,9 +138,10 @@ export default meta;
 type Story = StoryObj<DateRangeFieldProps>;
 
 export const Default: Story = {
-  render: (args: DateRangeFieldProps) => <DateRangeField {...args} />,
+  render: (args: DateRangeFieldProps) => <DateRangeField {...args} className="w-20" />,
   args: {
-    label: "Default DateRangeField",
+    labelFrom: "From",
+    labelTo: "To",
     withDatePicker: true,
   },
 };
@@ -150,7 +162,8 @@ export const InForm: Story = {
     );
   },
   args: {
-    label: "DateRangeField in Form",
+    labelFrom: "From",
+    labelTo: "To",
     withDatePicker: true,
   },
 };
@@ -158,7 +171,8 @@ export const InForm: Story = {
 export const WithLocale: Story = {
   render: (args: DateRangeFieldProps) => <DateRangeField {...args} />,
   args: {
-    label: "DateRangeField with German Locale",
+    labelFrom: "From",
+    labelTo: "To",
     locale: de,
     withDatePicker: true,
   },
@@ -167,7 +181,8 @@ export const WithLocale: Story = {
 export const WithError: Story = {
   render: (args: DateRangeFieldProps) => <DateRangeField {...args} />,
   args: {
-    label: "DateRangeField with Error",
+    labelFrom: "From",
+    labelTo: "To",
     error: "Please select valid dates",
     required: true,
     withDatePicker: true,
@@ -177,7 +192,8 @@ export const WithError: Story = {
 export const WithHint: Story = {
   render: (args: DateRangeFieldProps) => <DateRangeField {...args} />,
   args: {
-    label: "DateRangeField with Hint",
+    labelFrom: "From",
+    labelTo: "To",
     hint: "Select your date range",
     withDatePicker: true,
   },
@@ -186,7 +202,8 @@ export const WithHint: Story = {
 export const Disabled: Story = {
   render: (args: DateRangeFieldProps) => <DateRangeField {...args} />,
   args: {
-    label: "Disabled DateRangeField",
+    labelFrom: "From",
+    labelTo: "To",
     disabled: true,
     placeholder: "Select dates",
     withDatePicker: true,
@@ -196,7 +213,8 @@ export const Disabled: Story = {
 export const WithDateRestrictions: Story = {
   render: (args: DateRangeFieldProps) => <DateRangeField {...args} />,
   args: {
-    label: "DateRangeField with Restrictions",
+    labelFrom: "From",
+    labelTo: "To",
     withDatePicker: true,
     disabledBefore: new Date(),
     disabledAfter: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000), // 30 days from now
@@ -207,7 +225,8 @@ export const WithDateRestrictions: Story = {
 export const WithoutDatePicker: Story = {
   render: (args: DateRangeFieldProps) => <DateRangeField {...args} />,
   args: {
-    label: "DateRangeField without Picker",
+    labelFrom: "From",
+    labelTo: "To",
     withDatePicker: false,
     placeholder: "MM/DD/YYYY",
     hint: "Type the dates manually",
@@ -224,7 +243,8 @@ export const Controlled: Story = {
     return <DateRangeField {...args} value={value} onChange={setValue} />;
   },
   args: {
-    label: "Controlled DateRangeField",
+    labelFrom: "From",
+    labelTo: "To",
     withDatePicker: true,
     placeholder: "Select dates",
   },
@@ -240,7 +260,8 @@ const ControlledDateRangeField = () => {
 
   return (
     <DateRangeField
-      label="Controlled DateRangeField"
+      labelFrom="From"
+      labelTo="To"
       withDatePicker={true}
       placeholder="Select dates"
       value={value}
@@ -261,7 +282,8 @@ export const CustomStyled: Story = {
     <DateRangeField {...args} className="[&>div[data-symbiosis-textfield='hint']]:text-red-300" />
   ),
   args: {
-    label: "Custom Styled DateRangeField",
+    labelFrom: "From",
+    labelTo: "To",
     withDatePicker: true,
     hint: "This is a custom styled hint",
     placeholder: "Select dates",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24680,7 +24680,7 @@
     },
     "packages/ui": {
       "name": "@synopsisapp/symbiosis-ui",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.17.7",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synopsisapp/symbiosis-ui",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "license": "MIT",
   "type": "module",
   "main": "dist/symbiosis-ui.umd.js",

--- a/packages/ui/src/components/DateField/index.tsx
+++ b/packages/ui/src/components/DateField/index.tsx
@@ -123,7 +123,7 @@ const DateField = React.forwardRef(
           side="bottom"
           onOpenAutoFocus={(e) => e.preventDefault()}
           onCloseAutoFocus={(e) => e.preventDefault()}
-          className="w-[var(--radix-popover-trigger-width)] p-0 my-2"
+          className="w-[max(var(--radix-popover-trigger-width),100%)] p-0 my-2"
         >
           <DatePicker
             mode="single"

--- a/packages/ui/src/components/DateField/index.tsx
+++ b/packages/ui/src/components/DateField/index.tsx
@@ -35,6 +35,8 @@ const DateField = React.forwardRef(
       value && isValid(value) ? value : undefined,
     );
 
+    const containerRef = React.useRef<HTMLDivElement>(null);
+
     React.useEffect(() => {
       if (value && isValid(value)) {
         setInputValue(format(value, getDateFormat(locale)));
@@ -59,6 +61,12 @@ const DateField = React.forwardRef(
       setInputValue(format(date ?? new Date(), getDateFormat(locale)));
       onChange?.(date ?? new Date());
       setIsOpen(false);
+    };
+
+    const handleFocusOutside = (e: Event) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
     };
 
     if (!datePickerProps.withDatePicker) {
@@ -86,60 +94,64 @@ const DateField = React.forwardRef(
     }
 
     return (
-      <Popover.Root
-        open={isOpen}
-        onOpenChange={(open) => {
-          setIsOpen(open);
-        }}
-      >
-        <Popover.Trigger asChild>
-          <TextField
-            ref={ref}
-            error={error}
-            required={required}
-            hint={hint}
-            placeholder={placeholder}
-            icon={"symbiosis-calendar"}
-            disabled={disabled}
-            name={name}
-            size={size}
-            id={id}
-            label={label}
-            className={className}
-            value={inputValue}
-            onChange={handleInputChange}
-            onFocus={() => {
-              setIsOpen(true);
-            }}
-            onBlur={(value) => {
-              onBlur?.(value);
-            }}
-          />
-        </Popover.Trigger>
-
-        <Popover.Content
-          data-symbiosis-datefield="content"
-          align="start"
-          side="bottom"
-          onOpenAutoFocus={(e) => e.preventDefault()}
-          onCloseAutoFocus={(e) => e.preventDefault()}
-          className="w-[max(var(--radix-popover-trigger-width),100%)] p-0 my-2"
+      <div ref={containerRef} className="contents">
+        <Popover.Root
+          open={isOpen}
+          onOpenChange={(open) => {
+            setIsOpen(open);
+          }}
         >
-          <DatePicker
-            mode="single"
-            selectedDate={selectedDate ?? new Date()}
-            onSelect={handleSingleSelect}
-            disabledBefore={datePickerProps.disabledBefore}
-            disabledAfter={datePickerProps.disabledAfter}
-            disabledDays={datePickerProps.disabledDays}
-            booked={datePickerProps.booked}
-            onMonthChange={datePickerProps.onMonthChange}
-            locale={locale}
-            month={selectedDate}
-            className="p-2"
-          />
-        </Popover.Content>
-      </Popover.Root>
+          <Popover.Trigger asChild>
+            <TextField
+              ref={ref}
+              error={error}
+              required={required}
+              hint={hint}
+              placeholder={placeholder}
+              icon={"symbiosis-calendar"}
+              disabled={disabled}
+              name={name}
+              size={size}
+              id={id}
+              label={label}
+              className={className}
+              value={inputValue}
+              onChange={handleInputChange}
+              onFocus={() => {
+                setIsOpen(true);
+              }}
+              onBlur={(value) => {
+                onBlur?.(value);
+              }}
+              data-symbiosis-datefield="trigger"
+            />
+          </Popover.Trigger>
+
+          <Popover.Content
+            data-symbiosis-datefield="content"
+            align="start"
+            side="bottom"
+            onOpenAutoFocus={(e) => e.preventDefault()}
+            onCloseAutoFocus={(e) => e.preventDefault()}
+            onFocusOutside={handleFocusOutside}
+            className="w-[max(var(--radix-popover-trigger-width),100%)] p-0 my-2"
+          >
+            <DatePicker
+              mode="single"
+              selectedDate={selectedDate ?? new Date()}
+              onSelect={handleSingleSelect}
+              disabledBefore={datePickerProps.disabledBefore}
+              disabledAfter={datePickerProps.disabledAfter}
+              disabledDays={datePickerProps.disabledDays}
+              booked={datePickerProps.booked}
+              onMonthChange={datePickerProps.onMonthChange}
+              locale={locale}
+              month={selectedDate}
+              className="p-2"
+            />
+          </Popover.Content>
+        </Popover.Root>
+      </div>
     );
   },
 );

--- a/packages/ui/src/components/DateRangeField/index.tsx
+++ b/packages/ui/src/components/DateRangeField/index.tsx
@@ -18,7 +18,8 @@ const DateRangeField = React.forwardRef(
       name,
       size = "base",
       id,
-      label,
+      labelFrom,
+      labelTo,
       className,
       value,
       onChange,
@@ -36,6 +37,7 @@ const DateRangeField = React.forwardRef(
       from: value?.from,
       to: value?.to,
     });
+    const containerRef = React.useRef<HTMLDivElement>(null);
 
     React.useEffect(() => {
       if (value?.from && isValid(value.from)) {
@@ -98,6 +100,12 @@ const DateRangeField = React.forwardRef(
       }
     };
 
+    const handleFocusOutside = (e: Event) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
     const selectedDates = selectedRange.from ? { from: selectedRange.from, to: selectedRange.to } : undefined;
 
     if (!datePickerProps.withDatePicker) {
@@ -114,7 +122,7 @@ const DateRangeField = React.forwardRef(
             name={`${name}-from`}
             size={size}
             id={`${id}-from`}
-            label={label}
+            label={labelFrom}
             className={className}
             value={fromInputValue}
             onChange={handleFromInputChange}
@@ -130,7 +138,7 @@ const DateRangeField = React.forwardRef(
             name={`${name}-to`}
             size={size}
             id={`${id}-to`}
-            label={label}
+            label={labelTo}
             className={className}
             value={toInputValue}
             onChange={handleToInputChange}
@@ -143,7 +151,7 @@ const DateRangeField = React.forwardRef(
     return (
       <Popover.Root open={isOpen} onOpenChange={setIsOpen}>
         <Popover.Trigger asChild>
-          <div className="flex gap-2">
+          <div ref={containerRef} className="flex gap-2">
             <TextField
               ref={ref}
               error={error}
@@ -155,7 +163,7 @@ const DateRangeField = React.forwardRef(
               name={`${name}-from`}
               size={size}
               id={`${id}-from`}
-              label={label}
+              label={labelFrom}
               className={className}
               value={fromInputValue}
               onChange={handleFromInputChange}
@@ -172,7 +180,7 @@ const DateRangeField = React.forwardRef(
               name={`${name}-to`}
               size={size}
               id={`${id}-to`}
-              label={label}
+              label={labelTo}
               className={className}
               value={toInputValue}
               onChange={handleToInputChange}
@@ -188,6 +196,7 @@ const DateRangeField = React.forwardRef(
           side="bottom"
           onOpenAutoFocus={(e) => e.preventDefault()}
           onCloseAutoFocus={(e) => e.preventDefault()}
+          onFocusOutside={handleFocusOutside}
           className="w-[max(var(--radix-popover-trigger-width),100%)] p-0 my-2"
         >
           <DatePicker

--- a/packages/ui/src/components/DateRangeField/types.ts
+++ b/packages/ui/src/components/DateRangeField/types.ts
@@ -5,11 +5,13 @@ export type Value = {
   to?: Date;
 };
 
-type BaseDateRangeFieldProps = Omit<TextFieldProps, "value" | "onChange" | "defaultValue" | "icon"> & {
+type BaseDateRangeFieldProps = Omit<TextFieldProps, "value" | "onChange" | "defaultValue" | "icon" | "label"> & {
   value?: Value;
   onChange?: (range: Value) => void;
   withDatePicker?: boolean;
   locale?: Locale;
+  labelFrom?: string;
+  labelTo?: string;
 };
 
 type WithoutDatePicker = BaseDateRangeFieldProps & {

--- a/packages/ui/src/components/Popover/index.tsx
+++ b/packages/ui/src/components/Popover/index.tsx
@@ -34,7 +34,7 @@ const PopoverContent = ({
   closeIcon,
   tone = "monochrome-dark",
   onOpenAutoFocus,
-
+  onFocusOutside,
   onCloseAutoFocus,
 }: PopoverContentProps) => {
   return (
@@ -47,6 +47,7 @@ const PopoverContent = ({
         className={cn(sharedPopoverStyles, className)}
         onOpenAutoFocus={onOpenAutoFocus}
         onCloseAutoFocus={onCloseAutoFocus}
+        onFocusOutside={onFocusOutside}
       >
         {closeIcon && (
           <PopoverPrimitive.Close className="absolute top-1 right-1 focus-visible:outline-none" aria-label="Close">

--- a/packages/ui/src/components/Popover/types.ts
+++ b/packages/ui/src/components/Popover/types.ts
@@ -11,6 +11,7 @@ export type PopoverRootProps = {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   modal?: boolean;
+  ref?: React.Ref<HTMLButtonElement>;
 };
 
 export type PopoverContentProps = {
@@ -23,6 +24,7 @@ export type PopoverContentProps = {
   tone?: ButtonTone;
   onOpenAutoFocus?: (event: Event) => void;
   onCloseAutoFocus?: (event: Event) => void;
+  onFocusOutside?: (event: Event) => void;
 };
 
 export type PopoverArrowProps = RadixPopoverArrowProps & {


### PR DESCRIPTION
### This PR fixes:

- `Datepicker` to close when component loses focus for keyboard nav
- `DateRangeField` to accept 2 labels for the from and to inputs ( my bad )
- `DateField` to render full width `Datepicker` even if the input is smaller than the `Datepicker` content