### PR TITLE
Add skip composition prop for portal based comps

### DIFF
--- a/examples/storybook/src/stories/ShowcaseSkipComposition.stories.tsx
+++ b/examples/storybook/src/stories/ShowcaseSkipComposition.stories.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Modal, Popover, Dropdown, Button, Text } from "@synopsisapp/symbiosis-ui";
+
+const meta: Meta = {
+  title: "Examples/SkipComposition",
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+const NestedComponents = ({ skipCompositionForPopover = false, skipCompositionForDropdown = false }) => {
+  const PopoverContentWrapper = !skipCompositionForPopover ? Popover.Portal : React.Fragment;
+  const DropdownContentWrapper = !skipCompositionForDropdown ? Dropdown.Portal : React.Fragment;
+
+  return (
+    <Modal.Root>
+      <Modal.Trigger>
+        <Button label="Open Modal" />
+      </Modal.Trigger>
+      <Modal.Content title="Modal with nested components">
+        <div className="p-4">
+          <Text>This modal contains a Popover with a nested Dropdown</Text>
+
+          <div className="mt-4">
+            <Popover.Root>
+              <Popover.Trigger>
+                <Button label="Open Popover" />
+              </Popover.Trigger>
+              <PopoverContentWrapper>
+                <Popover.Content skipComposition={skipCompositionForPopover}>
+                  <div className="p-4">
+                    <Text>This is a Popover with a Dropdown</Text>
+
+                    <div className="mt-4">
+                      <Dropdown.Root>
+                        <Dropdown.Trigger>
+                          <Button label="Open Dropdown" />
+                        </Dropdown.Trigger>
+                        <DropdownContentWrapper>
+                          <Dropdown.Content skipComposition={skipCompositionForDropdown}>
+                            <Dropdown.SimpleItem text="Option 1" />
+                            <Dropdown.SimpleItem text="Option 2" />
+                            <Dropdown.SimpleItem text="Option 3" />
+                          </Dropdown.Content>
+                        </DropdownContentWrapper>
+                      </Dropdown.Root>
+                    </div>
+                  </div>
+                </Popover.Content>
+              </PopoverContentWrapper>
+            </Popover.Root>
+          </div>
+        </div>
+      </Modal.Content>
+    </Modal.Root>
+  );
+};
+
+export const WithPortals: Story = {
+  render: () => <NestedComponents skipCompositionForPopover={false} skipCompositionForDropdown={false} />,
+  name: "With Portals (Default) - it shouldnt work correctly",
+};
+
+export const WithoutPortals: Story = {
+  render: () => <NestedComponents skipCompositionForPopover={true} skipCompositionForDropdown={true} />,
+  name: "Without Portals - it should work correctly",
+};

--- a/examples/storybook/src/stories/ShowcaseSkipComposition.stories.tsx
+++ b/examples/storybook/src/stories/ShowcaseSkipComposition.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import { Modal, Popover, Dropdown, Button, Text } from "@synopsisapp/symbiosis-ui";
+import { Modal, Popover, Dropdown, Button, Text, cn } from "@synopsisapp/symbiosis-ui";
 
 const meta: Meta = {
   title: "Examples/SkipComposition",
@@ -12,9 +12,20 @@ const meta: Meta = {
 export default meta;
 type Story = StoryObj;
 
-const NestedComponents = ({ skipCompositionForPopover = false, skipCompositionForDropdown = false }) => {
+const NestedComponents = ({
+  skipCompositionForPopover = false,
+  skipCompositionForDropdown = false,
+  withZIndexes = false,
+}) => {
   const PopoverContentWrapper = !skipCompositionForPopover ? Popover.Portal : React.Fragment;
   const DropdownContentWrapper = !skipCompositionForDropdown ? Dropdown.Portal : React.Fragment;
+
+  const zIndexes = withZIndexes
+    ? {
+        popover: "z-[1000]",
+        dropdown: "z-[1001]",
+      }
+    : undefined;
 
   return (
     <Modal.Root>
@@ -31,7 +42,7 @@ const NestedComponents = ({ skipCompositionForPopover = false, skipCompositionFo
                 <Button label="Open Popover" />
               </Popover.Trigger>
               <PopoverContentWrapper>
-                <Popover.Content skipComposition={skipCompositionForPopover}>
+                <Popover.Content skipComposition={skipCompositionForPopover} className={cn(zIndexes?.popover)}>
                   <div className="p-4">
                     <Text>This is a Popover with a Dropdown</Text>
 
@@ -41,7 +52,10 @@ const NestedComponents = ({ skipCompositionForPopover = false, skipCompositionFo
                           <Button label="Open Dropdown" />
                         </Dropdown.Trigger>
                         <DropdownContentWrapper>
-                          <Dropdown.Content skipComposition={skipCompositionForDropdown}>
+                          <Dropdown.Content
+                            skipComposition={skipCompositionForDropdown}
+                            className={cn(zIndexes?.dropdown)}
+                          >
                             <Dropdown.SimpleItem text="Option 1" />
                             <Dropdown.SimpleItem text="Option 2" />
                             <Dropdown.SimpleItem text="Option 3" />
@@ -60,9 +74,14 @@ const NestedComponents = ({ skipCompositionForPopover = false, skipCompositionFo
   );
 };
 
-export const WithPortals: Story = {
+export const WithPortalsWithoutCorrectZIndexes: Story = {
   render: () => <NestedComponents skipCompositionForPopover={false} skipCompositionForDropdown={false} />,
-  name: "With Portals (Default) - it shouldnt work correctly",
+  name: "With Portals (Default) - it shouldnt work correctly since we dont have the correct zIndexes",
+};
+
+export const WithPortalsWithCorrectZIndexes: Story = {
+  render: () => <NestedComponents skipCompositionForPopover={false} skipCompositionForDropdown={false} withZIndexes />,
+  name: "With Portals (Default) - it should work correctly since we have the correct zIndexes",
 };
 
 export const WithoutPortals: Story = {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synopsisapp/symbiosis-ui",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "license": "MIT",
   "type": "module",
   "main": "dist/symbiosis-ui.umd.js",

--- a/packages/ui/src/components/Dropdown/index.tsx
+++ b/packages/ui/src/components/Dropdown/index.tsx
@@ -1,5 +1,5 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-
+import * as React from "react";
 import { Icon } from "../Icon";
 
 import { StopPropagation } from "../StopPropagation";
@@ -35,15 +35,18 @@ const DropdownTrigger = ({ children, isDisabled, className, asChild }: DropdownT
 
 DropdownTrigger.displayName = "DropdownTrigger";
 
-const DropdownContent = ({ children, side, className }: DropdownContentProps) => {
+const DropdownContent = ({ children, side, className, skipComposition = false }: DropdownContentProps) => {
   const contentClasses = cn(sharedDropdownContentStyles, className);
+  const ContentWrapper = skipComposition ? React.Fragment : DropdownMenu.Portal;
 
   const shadowsOffset = 5;
 
   return (
-    <DropdownMenu.Content className={contentClasses} side={side} sideOffset={shadowsOffset} avoidCollisions>
-      {children}
-    </DropdownMenu.Content>
+    <ContentWrapper>
+      <DropdownMenu.Content className={contentClasses} side={side} sideOffset={shadowsOffset} avoidCollisions>
+        {children}
+      </DropdownMenu.Content>
+    </ContentWrapper>
   );
 };
 

--- a/packages/ui/src/components/Dropdown/types.ts
+++ b/packages/ui/src/components/Dropdown/types.ts
@@ -16,6 +16,7 @@ export type DropdownContentProps = {
   children: React.ReactNode;
   side?: DropdownMenuContentProps["side"];
   className?: string;
+  skipComposition?: boolean;
 };
 
 export type DropdownItemProps = {

--- a/packages/ui/src/components/Modal/index.tsx
+++ b/packages/ui/src/components/Modal/index.tsx
@@ -42,7 +42,7 @@ const ModalContent: React.FC<React.PropsWithChildren<ModalContentProps>> = ({
 }) => (
   <ModalPrimitive.Content
     className={cn(
-      "fixed animate-slideUpModal w-full overflow-hidden bg-white px-0 pt-2 pb-0 rounded-tl-lg rounded-tr-lg rounded-bl-none rounded-br-none lg:pt-2 lg:rounded-lg lg:w-auto z-[999] bottom-0 left-0 lg:bottom-auto lg:top-1/2 lg:left-1/2 lg:-translate-x-1/2 lg:-translate-y-1/2 max-h-[80vh]",
+      "fixed animate-slideUpModal w-full overflow-hidden bg-white px-0 pt-2 pb-0 rounded-tl-lg rounded-tr-lg rounded-bl-none rounded-br-none lg:pt-2 lg:rounded-lg lg:w-fit z-[999] bottom-0 left-0 lg:bottom-auto lg:inset-0 lg:m-auto lg:h-fit max-h-[80vh]",
       className,
     )}
   >

--- a/packages/ui/src/components/Popover/index.tsx
+++ b/packages/ui/src/components/Popover/index.tsx
@@ -42,9 +42,12 @@ const PopoverContent = ({
   onOpenAutoFocus,
   onFocusOutside,
   onCloseAutoFocus,
+  skipComposition = false,
 }: PopoverContentProps) => {
+  const ContentWrapper = skipComposition ? React.Fragment : PopoverPrimitive.Portal;
+
   return (
-    <PopoverPrimitive.Portal>
+    <ContentWrapper>
       <PopoverPrimitive.Content
         avoidCollisions
         asChild={asChild}
@@ -59,7 +62,7 @@ const PopoverContent = ({
       >
         {children}
       </PopoverPrimitive.Content>
-    </PopoverPrimitive.Portal>
+    </ContentWrapper>
   );
 };
 
@@ -88,4 +91,5 @@ export const Popover = {
   Close: PopoverClose,
   Content: PopoverContent,
   Arrow: PopoverArrow,
+  Portal: PopoverPrimitive.Portal,
 };

--- a/packages/ui/src/components/Popover/types.ts
+++ b/packages/ui/src/components/Popover/types.ts
@@ -24,6 +24,7 @@ export type PopoverContentProps = {
   onOpenAutoFocus?: (event: Event) => void;
   onCloseAutoFocus?: (event: Event) => void;
   onFocusOutside?: (event: Event) => void;
+  skipComposition?: boolean;
 };
 
 export type PopoverArrowProps = {

--- a/packages/ui/src/components/Select/index.tsx
+++ b/packages/ui/src/components/Select/index.tsx
@@ -4,6 +4,7 @@ import { Icon } from "../Icon";
 import { text } from "../sharedStyles";
 
 import { cn } from "../../utils/cn";
+import type { SelectContentProps } from "./types";
 
 const SelectRoot = SelectPrimitive.Root;
 
@@ -65,36 +66,39 @@ const SelectScrollDownButton = React.forwardRef<
 ));
 SelectScrollDownButton.displayName = "Select.ScrollDownButton";
 
-const SelectContent = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => (
-  <SelectPrimitive.Portal>
-    <SelectPrimitive.Content
-      ref={ref}
-      className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-white text-slate-600 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        position === "popper" &&
-          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-        className,
-      )}
-      position={position}
-      {...props}
-    >
-      <SelectScrollUpButton />
-      <SelectPrimitive.Viewport
-        className={cn(
-          "p-1",
-          position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
-        )}
-      >
-        {children}
-      </SelectPrimitive.Viewport>
-      <SelectScrollDownButton />
-    </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
-));
+const SelectContent = React.forwardRef<React.ElementRef<typeof SelectPrimitive.Content>, SelectContentProps>(
+  ({ className, children, position = "popper", skipComposition = false, ...props }, ref) => {
+    const ContentWrapper = skipComposition ? React.Fragment : SelectPrimitive.Portal;
+
+    return (
+      <ContentWrapper>
+        <SelectPrimitive.Content
+          ref={ref}
+          className={cn(
+            "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-white text-slate-600 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+            position === "popper" &&
+              "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+            className,
+          )}
+          position={position}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.Viewport
+            className={cn(
+              "p-1",
+              position === "popper" &&
+                "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+            )}
+          >
+            {children}
+          </SelectPrimitive.Viewport>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Content>
+      </ContentWrapper>
+    );
+  },
+);
 SelectContent.displayName = "Select.Content";
 
 const SelectLabel = React.forwardRef<
@@ -151,4 +155,5 @@ export const Select = {
   Separator: SelectSeparator,
   ScrollUpButton: SelectScrollUpButton,
   ScrollDownButton: SelectScrollDownButton,
+  Portal: SelectPrimitive.Portal,
 };

--- a/packages/ui/src/components/Select/types.ts
+++ b/packages/ui/src/components/Select/types.ts
@@ -1,0 +1,5 @@
+import type * as SelectPrimitive from "@radix-ui/react-select";
+
+export type SelectContentProps = React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & {
+  skipComposition?: boolean;
+};

--- a/packages/ui/src/components/Tooltip/index.tsx
+++ b/packages/ui/src/components/Tooltip/index.tsx
@@ -1,4 +1,5 @@
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import * as React from "react";
 import { Text } from "../Text";
 import { cn } from "../../utils/cn";
 import type { TooltipRootProps, TooltipContentProps, TooltipTriggerProps } from "./types";
@@ -24,9 +25,12 @@ export const TooltipContent = ({
   align = "center",
   alignOffset = 0,
   className,
+  skipComposition = false,
 }: TooltipContentProps) => {
+  const ContentWrapper = skipComposition ? React.Fragment : TooltipPrimitive.Portal;
+
   return (
-    <TooltipPrimitive.Portal>
+    <ContentWrapper>
       <TooltipPrimitive.Content
         avoidCollisions
         side={side}
@@ -44,7 +48,7 @@ export const TooltipContent = ({
           children
         )}
       </TooltipPrimitive.Content>
-    </TooltipPrimitive.Portal>
+    </ContentWrapper>
   );
 };
 
@@ -64,4 +68,5 @@ export const Tooltip = {
   Root: TooltipRoot,
   Content: TooltipContent,
   Trigger: TooltipTrigger,
+  Portal: TooltipPrimitive.Portal,
 };

--- a/packages/ui/src/components/Tooltip/types.ts
+++ b/packages/ui/src/components/Tooltip/types.ts
@@ -13,6 +13,7 @@ export type TooltipContentProps = {
   align?: "start" | "center" | "end";
   alignOffset?: number;
   className?: string;
+  skipComposition?: boolean;
 };
 
 export type TooltipTriggerProps = {


### PR DESCRIPTION
### The Gist:

To avoid all the issues with the portals and the zIndex layers they may create when we combine multiple Symbiosis components, we decided to allow consumers to skip the portals in precomposed components and also expose the Portal of each respective component, so they can recompose that part as they see fit.

We also tweaked the modal content center-ing a bit, since we were using `transform`. Since the element is `fixed` and we used `transform` a new containing block for `fixed` positioning would be created, forcing any `Dropdowns` or similar components to be contained  in the modal and not overflow it, which didn't allow for very flexible UIs.


### This PR:
- Adds `skipComposition` prop and exports portal from `Dropdown`, `Popover`, `Select`, `Tooltip` components.
- Adjusts `Modal.Content` css 
- Adds examples on storybook that showcase the power of `skipComposition` with `Portal`
