### PR TITLE
Feat/tooltip component improvements

### DIFF
--- a/examples/storybook/src/stories/Tooltip.stories.tsx
+++ b/examples/storybook/src/stories/Tooltip.stories.tsx
@@ -18,6 +18,7 @@ const meta: Meta<typeof Tooltip.Root> = {
 export default meta;
 
 type Story = StoryObj<typeof Tooltip.Root>;
+type StoryContent = StoryObj<typeof Tooltip.Content>;
 
 export const Uncontrolled: Story = {
   render: (args: TooltipProps["Root"]) => (
@@ -107,6 +108,24 @@ export const CustomContent: Story = {
       <Tooltip.Content className="bg-mainColors-light-200 rounded-none">
         <div>Popover content</div>
       </Tooltip.Content>
+    </Tooltip.Root>
+  ),
+};
+
+export const CustomSideAndAlign: StoryContent = {
+  args: {
+    side: "right",
+    sideOffset: 0,
+    align: "end",
+    alignOffset: -50,
+  },
+
+  render: (args: TooltipProps["Content"]) => (
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        <span>Hover me for custom side</span>
+      </Tooltip.Trigger>
+      <Tooltip.Content label="Custom side" {...args} />
     </Tooltip.Root>
   ),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -25049,7 +25049,7 @@
     },
     "packages/ui": {
       "name": "@synopsisapp/symbiosis-ui",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.17.7",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synopsisapp/symbiosis-ui",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "license": "MIT",
   "type": "module",
   "main": "dist/symbiosis-ui.umd.js",

--- a/packages/ui/src/components/Tooltip/index.tsx
+++ b/packages/ui/src/components/Tooltip/index.tsx
@@ -16,12 +16,28 @@ export const TooltipRoot = ({ children, defaultOpen, open, onOpenChange }: Toolt
 
 TooltipRoot.displayName = "Tooltip.Root";
 
-export const TooltipContent = ({ children, label, className }: TooltipContentProps) => {
+export const TooltipContent = ({
+  children,
+  label,
+  side = "top",
+  sideOffset = 5,
+  align = "center",
+  alignOffset = 0,
+  className,
+}: TooltipContentProps) => {
   return (
     <TooltipPrimitive.Portal>
-      <TooltipPrimitive.Content sideOffset={5} forceMount className={cn(sharedTooltipStyles, className)}>
+      <TooltipPrimitive.Content
+        avoidCollisions
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        forceMount
+        className={cn(sharedTooltipStyles, className)}
+      >
         {label ? (
-          <Text variant="body-small-200" noTranslations className="m-0 p-0">
+          <Text variant="body-small-200" noTranslations className="m-0 p-0 text-inherit">
             {label}
           </Text>
         ) : (

--- a/packages/ui/src/components/Tooltip/types.ts
+++ b/packages/ui/src/components/Tooltip/types.ts
@@ -8,6 +8,10 @@ export type TooltipRootProps = {
 export type TooltipContentProps = {
   children?: React.ReactNode;
   label?: string;
+  side?: "top" | "right" | "bottom" | "left";
+  sideOffset?: number;
+  align?: "start" | "center" | "end";
+  alignOffset?: number;
   className?: string;
 };
 


### PR DESCRIPTION
Introduces five more props for `Tooltip.Content` component in order to provide more control for its' location.

- Adds `side` prop with the enum options `top` | `right` | `bottom` | `left`. **(defaults to `top`)**
- Adds `sideOffset` which will be the distance in px from the reference point. **(defaults to `5`)**

- Adds `align` prop with the enum options `start` | `center` | `end`. **(defaults to `center`)**
- Adds `alignOffset` which will be the distance in px from the reference point. **(defaults to `0`)**

- Adds `avoidCollisions` When true **(default)**, overrides the side and align preferences to prevent collisions with boundary edges.

- Added a Story to showcase it.