### PR TITLE
Feat/popover improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25049,7 +25049,7 @@
     },
     "packages/ui": {
       "name": "@synopsisapp/symbiosis-ui",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.17.7",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synopsisapp/symbiosis-ui",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "license": "MIT",
   "type": "module",
   "main": "dist/symbiosis-ui.umd.js",

--- a/packages/ui/src/components/Popover/index.tsx
+++ b/packages/ui/src/components/Popover/index.tsx
@@ -4,7 +4,13 @@ import { IconButton } from "../IconButton";
 import { cn } from "../../utils/cn";
 import { sharedPopoverStyles } from "./styles";
 
-import type { PopoverRootProps, PopoverContentProps, PopoverTriggerProps, PopoverArrowProps } from "./types";
+import type {
+  PopoverRootProps,
+  PopoverContentProps,
+  PopoverTriggerProps,
+  PopoverArrowProps,
+  PopoverCloseProps,
+} from "./types";
 
 const PopoverRoot = ({ children, defaultOpen, onOpenChange, open, modal = true }: PopoverRootProps) => {
   return (
@@ -33,9 +39,6 @@ const PopoverContent = ({
   align = "start",
   alignOffset = 0,
   className,
-  closeIcon,
-  closeButtonClassName,
-  tone = "monochrome-dark",
   onOpenAutoFocus,
   onFocusOutside,
   onCloseAutoFocus,
@@ -54,12 +57,6 @@ const PopoverContent = ({
         onCloseAutoFocus={onCloseAutoFocus}
         onFocusOutside={onFocusOutside}
       >
-        {closeIcon && (
-          <PopoverPrimitive.Close className="absolute top-1 right-1 focus-visible:outline-none" aria-label="Close">
-            <IconButton icon={closeIcon} tone={tone} variant="ghost" size="base" className="w-4 min-w-4 h-4 min-h-4" />
-          </PopoverPrimitive.Close>
-        )}
-
         {children}
       </PopoverPrimitive.Content>
     </PopoverPrimitive.Portal>
@@ -74,9 +71,21 @@ const PopoverArrow = ({ className }: PopoverArrowProps) => (
 
 PopoverArrow.displayName = "Popover.Arrow";
 
+const PopoverClose = ({ icon, tone, className }: PopoverCloseProps) => (
+  <PopoverPrimitive.Close
+    className={cn("absolute top-2 right-2 focus-visible:outline-none", className)}
+    aria-label="Close"
+  >
+    <IconButton icon={icon} tone={tone} variant="ghost" size="base" className="w-4 min-w-4 h-4 min-h-4" />
+  </PopoverPrimitive.Close>
+);
+
+PopoverClose.displayName = "Popover.Close";
+
 export const Popover = {
   Root: PopoverRoot,
   Trigger: PopoverTrigger,
+  Close: PopoverClose,
   Content: PopoverContent,
   Arrow: PopoverArrow,
 };

--- a/packages/ui/src/components/Popover/index.tsx
+++ b/packages/ui/src/components/Popover/index.tsx
@@ -29,9 +29,12 @@ const PopoverContent = ({
   children,
   asChild,
   side = "top",
+  sideOffset = 5,
   align = "start",
+  alignOffset = 0,
   className,
   closeIcon,
+  closeButtonClassName,
   tone = "monochrome-dark",
   onOpenAutoFocus,
   onFocusOutside,
@@ -43,7 +46,9 @@ const PopoverContent = ({
         avoidCollisions
         asChild={asChild}
         side={side}
+        sideOffset={sideOffset}
         align={align}
+        alignOffset={alignOffset}
         className={cn(sharedPopoverStyles, className)}
         onOpenAutoFocus={onOpenAutoFocus}
         onCloseAutoFocus={onCloseAutoFocus}

--- a/packages/ui/src/components/Popover/types.ts
+++ b/packages/ui/src/components/Popover/types.ts
@@ -18,9 +18,12 @@ export type PopoverContentProps = {
   children?: React.ReactNode;
   asChild?: boolean;
   side?: RadixPopoverContentProps["side"];
+  sideOffset?: RadixPopoverContentProps["sideOffset"];
   align?: RadixPopoverContentProps["align"];
+  alignOffset?: RadixPopoverContentProps["alignOffset"];
   className?: string;
   closeIcon?: IconProps["name"];
+  closeButtonClassName?: string;
   tone?: ButtonTone;
   onOpenAutoFocus?: (event: Event) => void;
   onCloseAutoFocus?: (event: Event) => void;

--- a/packages/ui/src/components/Popover/types.ts
+++ b/packages/ui/src/components/Popover/types.ts
@@ -1,5 +1,4 @@
 import type {
-  PopoverArrowProps as RadixPopoverArrowProps,
   PopoverContentProps as RadixPopoverContentProps,
 } from "@radix-ui/react-popover";
 import type { IconProps } from "../Icon/types";
@@ -27,7 +26,7 @@ export type PopoverContentProps = {
   onFocusOutside?: (event: Event) => void;
 };
 
-export type PopoverArrowProps = RadixPopoverArrowProps & {
+export type PopoverArrowProps = {
   className?: string;
 };
 

--- a/packages/ui/src/components/Popover/types.ts
+++ b/packages/ui/src/components/Popover/types.ts
@@ -22,15 +22,18 @@ export type PopoverContentProps = {
   align?: RadixPopoverContentProps["align"];
   alignOffset?: RadixPopoverContentProps["alignOffset"];
   className?: string;
-  closeIcon?: IconProps["name"];
-  closeButtonClassName?: string;
-  tone?: ButtonTone;
   onOpenAutoFocus?: (event: Event) => void;
   onCloseAutoFocus?: (event: Event) => void;
   onFocusOutside?: (event: Event) => void;
 };
 
 export type PopoverArrowProps = RadixPopoverArrowProps & {
+  className?: string;
+};
+
+export type PopoverCloseProps = {
+  icon: IconProps["name"];
+  tone: ButtonTone;
   className?: string;
 };
 


### PR DESCRIPTION
Introduces five more props for `Popover.Content` component in order to provide more control for its' location.

- Adds `sideOffset` which will be the distance in px from the reference point. **(defaults to `5`)**
- Adds `alignOffset` which will be the distance in px from the reference point. **(defaults to `0`)**

- Exposed `Popover.Close` component and removed it from `Popover.Content`
- Removed unused imports from `/types` file.