### PR TITLE
refactor(TextAreaField): use React.forwardRef to allow for ref forwarding

### DIFF
--- a/packages/ui/src/components/TextAreaField/index.tsx
+++ b/packages/ui/src/components/TextAreaField/index.tsx
@@ -6,7 +6,7 @@ import { Text } from "../Text";
 import { input, inputLabel } from "../sharedStyles";
 import type { TextAreaFieldProps } from "./types";
 
-export const TextAreaField = ({
+export const TextAreaField = React.forwardRef<HTMLTextAreaElement, TextAreaFieldProps>(({
   error,
   required,
   value,
@@ -24,9 +24,8 @@ export const TextAreaField = ({
   size = "base",
   labelWeight,
   className,
-}: TextAreaFieldProps) => {
+}: TextAreaFieldProps, ref) => {
   const formId = id ?? label ?? "";
-  const ref = React.useRef<HTMLTextAreaElement>(null);
 
   const hasError = Boolean(error);
 
@@ -121,4 +120,4 @@ export const TextAreaField = ({
       )}
     </div>
   );
-};
+});

--- a/packages/ui/src/components/TextAreaField/index.tsx
+++ b/packages/ui/src/components/TextAreaField/index.tsx
@@ -34,7 +34,7 @@ export const TextAreaField = React.forwardRef<HTMLTextAreaElement, TextAreaField
       {label && (
         <label
           htmlFor={formId}
-          data-symbiosis-textAreaField="label"
+          data-symbiosis-textareafield="label"
           className={cn(inputLabel({ size, weight: labelWeight }), "m-0")}
         >
           {label}
@@ -44,14 +44,14 @@ export const TextAreaField = React.forwardRef<HTMLTextAreaElement, TextAreaField
         <div className="flex h-auto flex-1">
           {icon && (
             <Icon
-              data-symbiosis-textAreaField="icon"
+              data-symbiosis-textareafield="icon"
               name={icon}
               className="absolute top-3 left-2 z-10 translate-y-[5px] text-gray-base"
               size="small-200"
             />
           )}
           <textarea
-            data-symbiosis-textAreaField="input"
+            data-symbiosis-textareafield="input"
             id={formId}
             name={name}
             className={cn(
@@ -83,7 +83,7 @@ export const TextAreaField = React.forwardRef<HTMLTextAreaElement, TextAreaField
       {hasError && (
         <div
           className="flex items-center gap-1"
-          data-symbiosis-textAreaField="error"
+          data-symbiosis-textareafield="error"
         >
           <Icon
             name="symbiosis-exclamation-circle"
@@ -102,7 +102,7 @@ export const TextAreaField = React.forwardRef<HTMLTextAreaElement, TextAreaField
       {!hasError && hint && (
         <div
           className="flex items-center gap-1 text-slate-400"
-          data-symbiosis-textAreaField="hint"
+          data-symbiosis-textareafield="hint"
         >
           <Icon
             name="symbiosis-exclamation-circle"

--- a/packages/ui/src/hooks/useToast.tsx
+++ b/packages/ui/src/hooks/useToast.tsx
@@ -49,13 +49,15 @@ const ToastContent = ({
   return (
     <div className={cn("flex items-center gap-2", className)}>
       {iconName && (
-        <Icon
-          name={iconName}
-          size="small-100"
-          className={cn("text-slate-700", {
-            "animate-spin": variant === "loading",
-          })}
-        />
+        <div>
+          <Icon
+            name={iconName}
+            size="small-100"
+            className={cn("text-slate-700", {
+              "animate-spin": variant === "loading",
+            })}
+          />
+        </div>
       )}
       <div className="flex flex-col gap-1">
         <Text


### PR DESCRIPTION
Closes #54 
Closes #52 
Closes #55 

The changes in this commit are aimed at improving the TextAreaField component by using the React.forwardRef higher-order component. This allows the component to forward the ref to the underlying textarea element, making it easier for consumers of the component to access and manipulate the textarea directly if needed.

The main changes are:

1. Wrapped the TextAreaField component in a React.forwardRef call, which takes in the props and a ref parameter.
2. Passed the ref parameter to the textarea element in the component's JSX.
3. Removed the unnecessary ref variable declaration and assignment, as the ref is now passed directly to the textarea.

This change makes the TextAreaField component more flexible and easier to use, as consumers can now access the underlying textarea element through the ref.